### PR TITLE
Allow humanized CSV headers

### DIFF
--- a/lib/bank_statements_csv_parser.rb
+++ b/lib/bank_statements_csv_parser.rb
@@ -46,7 +46,7 @@ private
   end
 
   def parse_field(row, index, field_name)
-    self.send("parse_#{field_name}", row[field_name])
+    self.send("parse_#{field_name}", row[field_name] || row[field_name.humanize])
   rescue StandardError => e
     raise CsvRowParsingException.new(e.message, field_name, index)
   end

--- a/spec/lib/bank_statements_csv_parser_spec.rb
+++ b/spec/lib/bank_statements_csv_parser_spec.rb
@@ -144,6 +144,18 @@ describe BankStatementsCsvParser do
         :amount => 155.55
       })
     end
+
+    it 'should return the correct hash when the row is correct even if column names are capitalized' do
+      expect(parser.send(:parse_line, {
+        "Description" => "Test",
+        "Date" => "2018-01-05",
+        "Amount" => "155.55"
+      }, 1)).to eq({
+        :description => "Test",
+        :date => Date.new(2018,1,5),
+        :amount => 155.55
+      })
+    end
   end
 
   describe '#parse' do


### PR DESCRIPTION
Also allow the CSV header column names to be humanized:
- `Description`
- `Date`
- `Amount`