### PR TITLE
Ability to navigate to the create statement page from an account

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -13,7 +13,6 @@
 //= require jquery
 //= require jquery_ujs
 //= require bootstrap-sprockets
-//= require bootstrap
 //= require turbolinks
 //= require_tree .
 

--- a/app/assets/stylesheets/bootstraply/bootstraply.scss
+++ b/app/assets/stylesheets/bootstraply/bootstraply.scss
@@ -1,7 +1,4 @@
 @import "../variables";
-$font-size-h1: 2rem;
-$font-size-h2: 1.6rem;
-$font-size-h3: 1.2rem;
 
 // $theme-colors: (
 //   "primary": $primary-color

--- a/app/assets/stylesheets/bootstraply/modals.scss
+++ b/app/assets/stylesheets/bootstraply/modals.scss
@@ -1,0 +1,18 @@
+@import "../variables";
+
+.modal {
+  .modal-header {
+    &.modal-header-primary {
+      background-color: $primary-background-color;
+      border-color: $primary-background-color;
+      .modal-title {
+        color: $primary-color-with-background;
+      }
+    }
+    .modal-title {
+      display: inline;
+      font-weight: bold;
+      font-size: $font-size-h1;
+    }
+  }
+}

--- a/app/assets/stylesheets/bootstraply/panels.scss
+++ b/app/assets/stylesheets/bootstraply/panels.scss
@@ -3,7 +3,7 @@
 .panel {
   &.panel {
     .panel-heading {
-      font-size: 1.5em;
+      font-size: $font-size-h1;
       padding: 5px 15px;
     }
   }

--- a/app/assets/stylesheets/styles.scss
+++ b/app/assets/stylesheets/styles.scss
@@ -24,3 +24,11 @@ table td .audit-description {
     font-size: 90%;
   }
 }
+
+.cursor-help {
+  cursor: help;
+}
+
+.cursor-pointer {
+  cursor: pointer;
+}

--- a/app/assets/stylesheets/variables.scss
+++ b/app/assets/stylesheets/variables.scss
@@ -5,3 +5,7 @@ $primary-constrast-color: white;
 $primary-background-color: $primary-color;
 $primary-background-color-hover: $primary-color-hover;
 $primary-color-with-background: $primary-constrast-color;
+
+$font-size-h1: 2rem;
+$font-size-h2: 1.6rem;
+$font-size-h3: 1.2rem;

--- a/app/controllers/bank_statements_controller.rb
+++ b/app/controllers/bank_statements_controller.rb
@@ -19,7 +19,7 @@ class BankStatementsController < ApplicationController
 
   # GET /bank_statements/new
   def new
-    @bank_statement = BankStatement.new
+    @bank_statement = BankStatement.new(:bank_account_id => params[:bank_account_id])
   end
 
   # GET /bank_statements/1/edit

--- a/app/views/bank_accounts/_form.html.erb
+++ b/app/views/bank_accounts/_form.html.erb
@@ -5,7 +5,7 @@
   is_editing = bank_account.id.present?
   title = is_editing ? "Editing #{bank_account.name}" : "New #{type}"
   submit_btn = is_editing ? "Update" : "Create"
-  glyphicon = "glyphicon #{is_editing ? 'glyphicon-pencil' : 'glyphicon-plus'}"
+  glyphicon = Icons::add_or_edit(is_editing)
 %>
 <ol class="breadcrumb">
   <li><a href="/">Home</a></li>

--- a/app/views/bank_accounts/index.html.erb
+++ b/app/views/bank_accounts/index.html.erb
@@ -29,5 +29,5 @@
 <br>
 
 <%= link_to(new_bank_account_path, class: "btn btn-primary pull-right") do %>
-  <i class="glyphicon glyphicon-plus"></i> New Bank Account
+  <i class="<%= Icons::ADD %>"></i> New Bank Account
 <% end %>

--- a/app/views/bank_accounts/show.html.erb
+++ b/app/views/bank_accounts/show.html.erb
@@ -50,13 +50,13 @@
   </div>
   <div class="panel-footer">
     <%= link_to(edit_bank_account_path(@bank_account), :class => "btn btn-success pull-right") do %>
-      <i class="glyphicon glyphicon-pencil"></i> Edit Bank Account
+      <i class="<%= Icons::EDIT %>"></i> Edit Bank Account
     <% end %>
     <%= link_to(new_bank_statement_path(:bank_account_id => @bank_account.id), :class => "btn btn-primary pull-right") do %>
       <i class="<%= Icons::ADD %>"></i> New Statement
     <% end %>
     <%= link_to(bank_account_path(@bank_account), :class => "btn btn-danger pull-right", method: :delete, data: { confirm: 'Are you sure?' }) do %>
-      <i class="glyphicon glyphicon-trash"></i> Delete
+      <i class="<%= Icons::DELETE %>"></i> Delete
     <% end %>
   </div>
 </div>

--- a/app/views/bank_accounts/show.html.erb
+++ b/app/views/bank_accounts/show.html.erb
@@ -52,6 +52,9 @@
     <%= link_to(edit_bank_account_path(@bank_account), :class => "btn btn-success pull-right") do %>
       <i class="glyphicon glyphicon-pencil"></i> Edit Bank Account
     <% end %>
+    <%= link_to(new_bank_statement_path(:bank_account_id => @bank_account.id), :class => "btn btn-primary pull-right") do %>
+      <i class="<%= Icons::ADD %>"></i> New Statement
+    <% end %>
     <%= link_to(bank_account_path(@bank_account), :class => "btn btn-danger pull-right", method: :delete, data: { confirm: 'Are you sure?' }) do %>
       <i class="glyphicon glyphicon-trash"></i> Delete
     <% end %>

--- a/app/views/bank_statements/_form.html.erb
+++ b/app/views/bank_statements/_form.html.erb
@@ -27,6 +27,17 @@
       <%= render :partial => "layouts/form_errors_panel", :locals => {:object => bank_statement} %>
 
       <div class="form-group">
+        <%= f.label :bank_account_id, "Bank account:", class: css_col_label %>
+        <div class="<%= css_col_input %>">
+          <%= f.select :bank_account_id,
+            options_for_select(@bank_accounts, bank_statement.bank_account_id),
+            {:prompt => "<Select a Bank Account>"},
+            {:class => "form-control", :required => true}
+          %>
+        </div>
+      </div>
+
+      <div class="form-group">
         <%= f.label :month, "Period:", class: css_col_label %>
         <div class="col-md-4">
           <%=
@@ -46,18 +57,6 @@
         </div>
       </div>
 
-      <div class="form-group">
-        <%= f.label :bank_account_id, "Bank account:", class: css_col_label %>
-        <div class="<%= css_col_input %>">
-          <%= f.select :bank_account_id,
-            options_for_select(@bank_accounts, bank_statement.bank_account_id),
-            {:prompt => "<Select a Bank Account>"},
-            {:class => "form-control", :required => true}
-          %>
-        </div>
-      </div>
-
-
        <% if bank_statement.new_record? %>
           <div class="form-group">
             <%= f.label :records_text, "Records:", class: css_col_label %>
@@ -69,7 +68,10 @@
           <div class="form-group">
             <label class="<%= css_col_label %>">Options:</label>
             <div class="<%= css_col_input %> cell-label">
-              <div><label class="reset"><%= f.check_box :csv_parsing %> Records are provided with CSV format</label></div>
+              <div>
+                <label class="reset"><%= f.check_box :csv_parsing %> Records are provided within CSV format</label>
+                <i class="<%= Icons::INFO %> cursor-pointer" data-toggle="modal" data-target="#csv-tips-modal"></i>
+              </div>
             </div>
           </div>
       <% end %>
@@ -83,3 +85,22 @@
     </div>
   </div>
 <% end %>
+
+<div class="modal" id="csv-tips-modal" tabindex="-1" role="dialog">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <div class="modal-header modal-header-primary">
+        <span class="modal-title">CSV Tips</span>
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+          <span aria-hidden="true">&times;</span>
+        </button>
+      </div>
+      <div class="modal-body">
+        <%= render :partial => 'statement_records/csv_tips' %>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-primary" data-dismiss="modal">Close</button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/bank_statements/_form.html.erb
+++ b/app/views/bank_statements/_form.html.erb
@@ -5,7 +5,7 @@
   is_editing = bank_statement.id
   title = is_editing ? "Editing #{bank_statement.name}" : "New #{type}"
   submit_btn = is_editing ? "Update" : "Create"
-  glyphicon = "glyphicon #{is_editing ? 'glyphicon-pencil' : 'glyphicon-plus'}"
+  glyphicon = Icons::add_or_edit(is_editing)
 
   next_year = Date.today.year + 1
   years = (0..BankStatementsController::NB_YEARS-1).map{ |i| next_year-i }

--- a/app/views/bank_statements/index.html.erb
+++ b/app/views/bank_statements/index.html.erb
@@ -32,5 +32,5 @@
 <br>
 
 <%= link_to(new_bank_statement_path, class: "btn btn-primary pull-right") do %>
-  <i class="glyphicon glyphicon-plus"></i> New Bank Statement
+  <i class="<%= Icons::ADD %>"></i> New Bank Statement
 <% end %>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -18,7 +18,7 @@
 				<% if user_signed_in? %>
 					<li class="dropdown">
 						<a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
-							<i class="glyphicon glyphicon-cog"></i>
+							<i class="<%= Icons::MANAGE %>"></i>
 							Manage
 							<span class="caret"></span>
 						</a>
@@ -49,7 +49,7 @@
 						</ul>
 					</li>
 					<li><%= link_to(destroy_user_session_path, :method => :delete) do %>
-						<i class="glyphicon glyphicon-log-out"></i>
+						<i class="<%= Icons::LOGOUT %>"></i>
 						Logout
 					<% end %></li>
 				<% else %>

--- a/app/views/statement_parsers/_form.html.erb
+++ b/app/views/statement_parsers/_form.html.erb
@@ -7,7 +7,7 @@
   form_url = {:controller => "statement_parsers", :action => is_editing ? 'update' : 'create'}
   form_html_opts = {:class => "form-horizontal", :data_type => "form-statement-parser"}
   submit_btn = is_editing ? "Update" : "Create"
-  glyphicon = "glyphicon #{is_editing ? 'glyphicon-pencil' : 'glyphicon-plus'}"
+  glyphicon = Icons::add_or_edit(is_editing)
 %>
 <ol class="breadcrumb">
   <li><a href="/">Home</a></li>
@@ -51,7 +51,7 @@
             <div class="input-group">
               <%= f.text_field :plain_text_regex, class: "form-control" %>
               <span class="input-group-btn">
-                <a class="btn btn-default" on-click-callback="regexpFormat"><i class="glyphicon glyphicon-info-sign"></i></a>
+                <a class="btn btn-default" on-click-callback="regexpFormat"><i class="<%= Icons::INFO %>"></i></a>
               </span>
             </div>
           </div>
@@ -63,7 +63,7 @@
             <div class="input-group">
               <%= f.text_field :plain_text_date_format, class: "form-control" %>
               <span class="input-group-btn">
-                <a class="btn btn-default" on-click-callback="helpRubyDateFormat"><i class="glyphicon glyphicon-info-sign"></i></a>
+                <a class="btn btn-default" on-click-callback="helpRubyDateFormat"><i class="<%= Icons::INFO %>"></i></a>
               </span>
             </div>
           </div>

--- a/app/views/statement_parsers/index.html.erb
+++ b/app/views/statement_parsers/index.html.erb
@@ -29,5 +29,5 @@
 <br>
 
 <%= link_to(new_statement_parser_path, class: "btn btn-primary pull-right") do %>
-  <i class="glyphicon glyphicon-plus"></i> New Statement Parser
+  <i class="<%= Icons::ADD %>"></i> New Statement Parser
 <% end %>

--- a/app/views/statement_parsers/show.html.erb
+++ b/app/views/statement_parsers/show.html.erb
@@ -38,10 +38,10 @@
   </div>
   <div class="panel-footer">
     <%= link_to(edit_statement_parser_path(@parser), :class => "btn btn-success pull-right") do %>
-      <i class="glyphicon glyphicon-pencil"></i> Edit Statement Parser
+      <i class="<%= Icons::EDIT %>"></i> Edit Statement Parser
     <% end %>
     <%= link_to(statement_parser_path(@parser), :class => "btn btn-danger pull-right", method: :delete, data: { confirm: 'Are you sure?' }) do %>
-      <i class="glyphicon glyphicon-trash"></i> Delete
+      <i class="<%= Icons::DELETE %>"></i> Delete
     <% end %>
   </div>
 </div>

--- a/app/views/statement_records/_csv_tips.html.erb
+++ b/app/views/statement_records/_csv_tips.html.erb
@@ -1,0 +1,9 @@
+    The CSV file must contain all required columns:
+    <ul>
+      <li><span class="font-pre">description</span>: description of the transaction.</li>
+      <li><span class="font-pre">date</span>: date of the transaction. Should be formatted as <span class="font-pre">YYYY-MM-DD</span> or <span class="font-pre">YYYY/MM/DD</span>.</li>
+      <li><span class="font-pre">amount</span>: amount of the transaction. Can be prefixed by <span class="font-pre">+</span> or <span class="font-pre">-</span>.</li>
+    </ul>
+    <div><b>Sample</b>:</div>
+    <pre>"description","date","amount"
+"Transaction 1","2017/12/31","+1,123.89"</pre>

--- a/app/views/statement_records/_form.html.erb
+++ b/app/views/statement_records/_form.html.erb
@@ -5,7 +5,7 @@
   is_editing = statement_record.id.present?
   title = is_editing ? "Editing #{statement_record.name}" : "New #{type}"
   submit_btn = is_editing ? "Update" : "Create"
-  glyphicon = "glyphicon #{is_editing ? 'glyphicon-pencil' : 'glyphicon-plus'}"
+  glyphicon = Icons::add_or_edit(is_editing)
   transactions_link = @bank_statement.present? ? bank_statement_statement_records_path(@bank_statement) : statement_records_path
   from_opts = {:html => {:class => "form-horizontal center"}}
   from_opts[:url] = bank_statement_statement_record_path(@bank_statement, statement_record) if @bank_statement.present?

--- a/app/views/statement_records/index.html.erb
+++ b/app/views/statement_records/index.html.erb
@@ -44,5 +44,5 @@
 <br>
 
 <%= link_to(new_statement_record_path, class: "btn btn-primary pull-right") do %>
-  <i class="glyphicon glyphicon-plus"></i> New Transactions
+  <i class="<%= Icons::ADD %>"></i> New Transactions
 <% end %>

--- a/app/views/statement_records/show.html.erb
+++ b/app/views/statement_records/show.html.erb
@@ -62,10 +62,10 @@
   </div>
   <div class="panel-footer">
     <%= link_to(edit_btn_link, :class => "btn btn-success pull-right") do %>
-      <i class="glyphicon glyphicon-pencil"></i> Edit Transaction
+      <i class="<%= Icons::EDIT %>"></i> Edit Transaction
     <% end %>
     <%= link_to(del_btn_link, :class => "btn btn-danger pull-right", method: :delete, data: { confirm: 'Are you sure?' }) do %>
-      <i class="glyphicon glyphicon-trash"></i> Delete
+      <i class="<%= Icons::DELETE %>"></i> Delete
     <% end %>
   </div>
 </div>

--- a/app/views/statement_records/upload_csv.html.erb
+++ b/app/views/statement_records/upload_csv.html.erb
@@ -68,15 +68,7 @@
     Help
   </div>
   <div class="panel-body">
-    The CSV file must contain all required columns:
-    <ul>
-      <li><span class="font-pre">description</span>: description of the transaction.</li>
-      <li><span class="font-pre">date</span>: date of the transaction. Should be formatted as <span class="font-pre">YYYY-MM-DD</span> or <span class="font-pre">YYYY/MM/DD</span>.</li>
-      <li><span class="font-pre">amount</span>: amount of the transaction. Can be prefixed by <span class="font-pre">+</span> or <span class="font-pre">-</span>.</li>
-    </ul>
-    <div><b>Sample</b>:</div>
-    <pre>"description","date","amount"
-"Transaction 1","2017/12/31","+1,123.89"</pre>
+<%= render :partial => 'csv_tips' %>
   </div>
 </div>
 

--- a/lib/icons.rb
+++ b/lib/icons.rb
@@ -9,10 +9,18 @@ class Icons
   STATEMENT_RECORD_CATEGORY = "glyphicon glyphicon-glass"
   STATEMENT_RECORD_CATEGORY_RULE = "glyphicon glyphicon-ok"
 
+  ADD    = "glyphicon glyphicon-plus"
   EDIT   = "glyphicon glyphicon-pencil"
   DELETE = "glyphicon glyphicon-trash"
   INFO   = "glyphicon glyphicon-info-sign"
   IMPORT = "glyphicon glyphicon-import"
   UPLOAD = "glyphicon glyphicon-upload"
+
+  MANAGE = "glyphicon glyphicon-cog"
+  LOGOUT = "glyphicon glyphicon-log-out"
+
+  def self.add_or_edit(editing)
+    editing ? EDIT : ADD
+  end
 
 end


### PR DESCRIPTION
This PR also:
- remove `glyphicons` usages by using `Icons::<ICON_NAME>` instead
- styling of modals
- modal toggle to provide instructions for CSV import of statements